### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/riyadhbiyram/165c4af1-d294-475d-8f2a-b32aa072e19d/d1914dd7-1e3c-4956-a269-376756f18b70/_apis/work/boardbadge/4d4b0f1e-524c-4855-95fe-c0209649e010)](https://dev.azure.com/riyadhbiyram/165c4af1-d294-475d-8f2a-b32aa072e19d/_boards/board/t/d1914dd7-1e3c-4956-a269-376756f18b70/Microsoft.RequirementCategory)
 # vidly-mvc-5


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/riyadhbiyram/165c4af1-d294-475d-8f2a-b32aa072e19d/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.

New rule